### PR TITLE
Relax wavelength tests to allow a small difference in expected/actual values

### DIFF
--- a/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
+++ b/components/test-suite/src/loci/tests/testng/FormatReaderTest.java
@@ -1106,7 +1106,7 @@ public class FormatReaderTest {
         }
 
         if (realWavelength == null || expectedWavelength == null ||
-          !expectedWavelength.equals(realWavelength.getValue()))
+          Math.abs(expectedWavelength - realWavelength.getValue()) > Constants.EPSILON)
         {
           result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength + ")");
         }
@@ -1135,7 +1135,7 @@ public class FormatReaderTest {
         }
 
         if (realWavelength == null || expectedWavelength == null ||
-          !expectedWavelength.equals(realWavelength.getValue()))
+          Math.abs(expectedWavelength - realWavelength.getValue()) > Constants.EPSILON)
         {
           result(testName, false, "Series " + i + " channel " + c + " (expected " + expectedWavelength + ", actual " + realWavelength + ")");
         }


### PR DESCRIPTION
If the absolute value of the difference is less than Constants.EPSILON,
then the test will pass; this should prevent false negatives from minor
differences in precision.
