### PR TITLE
Add new methods to MetadataConverter

### DIFF
--- a/components/formats-api/src/loci/formats/meta/MetadataConverter.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataConverter.java
@@ -38,6 +38,8 @@
 
 package loci.formats.meta;
 
+import java.util.Map;
+
 import ome.xml.model.*;
 import ome.xml.model.enums.*;
 import ome.xml.model.primitives.*;
@@ -77,6 +79,7 @@ public final class MetadataConverter {
     convertFileAnnotations(src, dest);
     convertListAnnotations(src, dest);
     convertLongAnnotations(src, dest);
+    convertMapAnnotations(src, dest);
     convertTagAnnotations(src, dest);
     convertTermAnnotations(src, dest);
     convertTimestampAnnotations(src, dest);
@@ -92,6 +95,8 @@ public final class MetadataConverter {
     convertScreens(src, dest);
     convertDatasets(src, dest);
     convertProjects(src, dest);
+
+    convertRootAttributes(src, dest);
   }
 
   // -- Helper methods --
@@ -128,6 +133,12 @@ public final class MetadataConverter {
       try {
         Boolean value = src.getBooleanAnnotationValue(i);
         dest.setBooleanAnnotationValue(value, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        String annotator = src.getBooleanAnnotationAnnotator(i);
+        dest.setBooleanAnnotationAnnotator(annotator, i);
       }
       catch (NullPointerException e) { }
 
@@ -178,6 +189,12 @@ public final class MetadataConverter {
       try {
         String value = src.getCommentAnnotationValue(i);
         dest.setCommentAnnotationValue(value, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        String annotator = src.getCommentAnnotationAnnotator(i);
+        dest.setCommentAnnotationAnnotator(annotator, i);
       }
       catch (NullPointerException e) { }
 
@@ -294,6 +311,12 @@ public final class MetadataConverter {
       try {
         Double value = src.getDoubleAnnotationValue(i);
         dest.setDoubleAnnotationValue(value, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        String annotator = src.getDoubleAnnotationAnnotator(i);
+        dest.setDoubleAnnotationAnnotator(annotator, i);
       }
       catch (NullPointerException e) { }
 
@@ -587,6 +610,12 @@ public final class MetadataConverter {
       catch (NullPointerException e) { }
 
       try {
+        String annotator = src.getFileAnnotationAnnotator(i);
+        dest.setFileAnnotationAnnotator(annotator, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
         String fileName = src.getBinaryFileFileName(i);
         dest.setBinaryFileFileName(fileName, i);
       }
@@ -691,6 +720,12 @@ public final class MetadataConverter {
       try {
         PercentFraction humidity = src.getImagingEnvironmentHumidity(i);
         dest.setImagingEnvironmentHumidity(humidity, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        Map<String, String> map = src.getImagingEnvironmentMap(i);
+        dest.setImagingEnvironmentMap(map, i);
       }
       catch (NullPointerException e) { }
 
@@ -991,6 +1026,13 @@ public final class MetadataConverter {
             catch (NullPointerException e) { }
 
             try {
+              PositiveInteger integration =
+                src.getDetectorSettingsIntegration(i, c);
+              dest.setDetectorSettingsIntegration(integration, i, c);
+            }
+            catch (NullPointerException e) { }
+
+            try {
               Double offset = src.getDetectorSettingsOffset(i, c);
               dest.setDetectorSettingsOffset(offset, i, c);
             }
@@ -1005,6 +1047,12 @@ public final class MetadataConverter {
             try {
               Double voltage = src.getDetectorSettingsVoltage(i, c);
               dest.setDetectorSettingsVoltage(voltage, i, c);
+            }
+            catch (NullPointerException e) { }
+
+            try {
+              Double zoom = src.getDetectorSettingsZoom(i, c);
+              dest.setDetectorSettingsZoom(zoom, i, c);
             }
             catch (NullPointerException e) { }
           }
@@ -1656,6 +1704,12 @@ public final class MetadataConverter {
       }
       catch (NullPointerException e) { }
 
+      try {
+        String annotator = src.getListAnnotationAnnotator(i);
+        dest.setListAnnotationAnnotator(annotator, i);
+      }
+      catch (NullPointerException e) { }
+
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getListAnnotationAnnotationCount(i);
@@ -1706,6 +1760,12 @@ public final class MetadataConverter {
       }
       catch (NullPointerException e) { }
 
+      try {
+        String annotator = src.getLongAnnotationAnnotator(i);
+        dest.setLongAnnotationAnnotator(annotator, i);
+      }
+      catch (NullPointerException e) { }
+
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getLongAnnotationAnnotationCount(i);
@@ -1715,6 +1775,61 @@ public final class MetadataConverter {
         try {
           String id = src.getLongAnnotationAnnotationRef(i, a);
           dest.setLongAnnotationAnnotationRef(id, i, a);
+        }
+        catch (NullPointerException e) { }
+      }
+    }
+  }
+
+  private static void convertMapAnnotations(MetadataRetrieve src, MetadataStore dest)
+  {
+    int mapAnnotationCount = 0;
+    try {
+      mapAnnotationCount = src.getMapAnnotationCount();
+    }
+    catch (NullPointerException e) { }
+    for (int i=0; i<mapAnnotationCount; i++) {
+      try {
+        String id = src.getMapAnnotationID(i);
+        dest.setMapAnnotationID(id, i);
+      }
+      catch (NullPointerException e) {
+        continue;
+      }
+
+      try {
+        String description = src.getMapAnnotationDescription(i);
+        dest.setMapAnnotationDescription(description, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        String namespace = src.getMapAnnotationNamespace(i);
+        dest.setMapAnnotationNamespace(namespace, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        Map<String, String> value = src.getMapAnnotationValue(i);
+        dest.setMapAnnotationValue(value, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        String annotator = src.getMapAnnotationAnnotator(i);
+        dest.setMapAnnotationAnnotator(annotator, i);
+      }
+      catch (NullPointerException e) { }
+
+      int annotationRefCount = 0;
+      try {
+        annotationRefCount = src.getMapAnnotationAnnotationCount(i);
+      }
+      catch (NullPointerException e) { }
+      for (int a=0; a<annotationRefCount; a++) {
+        try {
+          String id = src.getMapAnnotationAnnotationRef(i, a);
+          dest.setMapAnnotationAnnotationRef(id, i, a);
         }
         catch (NullPointerException e) { }
       }
@@ -3316,6 +3431,12 @@ public final class MetadataConverter {
       }
       catch (NullPointerException e) { }
 
+      try {
+        String annotator = src.getTagAnnotationAnnotator(i);
+        dest.setTagAnnotationAnnotator(annotator, i);
+      }
+      catch (NullPointerException e) { }
+
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getTagAnnotationAnnotationCount(i);
@@ -3363,6 +3484,12 @@ public final class MetadataConverter {
       try {
         String value = src.getTermAnnotationValue(i);
         dest.setTermAnnotationValue(value, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        String annotator = src.getTermAnnotationAnnotator(i);
+        dest.setTermAnnotationAnnotator(annotator, i);
       }
       catch (NullPointerException e) { }
 
@@ -3416,6 +3543,12 @@ public final class MetadataConverter {
       }
       catch (NullPointerException e) { }
 
+      try {
+        String annotator = src.getTimestampAnnotationAnnotator(i);
+        dest.setTimestampAnnotationAnnotator(annotator, i);
+      }
+      catch (NullPointerException e) { }
+
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getTimestampAnnotationAnnotationCount(i);
@@ -3463,6 +3596,12 @@ public final class MetadataConverter {
       try {
         String value = src.getXMLAnnotationValue(i);
         dest.setXMLAnnotationValue(value, i);
+      }
+      catch (NullPointerException e) { }
+
+      try {
+        String annotator = src.getXMLAnnotationAnnotator(i);
+        dest.setXMLAnnotationAnnotator(annotator, i);
       }
       catch (NullPointerException e) { }
 
@@ -3611,6 +3750,63 @@ public final class MetadataConverter {
           if (filamentType != null) {
             dest.setFilamentType(filamentType, instrumentIndex, lightSource);
           }
+        }
+        catch (NullPointerException e) { }
+      }
+      else if (type.equals("GenericExcitationSource")) {
+        try {
+          String id =
+            src.getGenericExcitationSourceID(instrumentIndex, lightSource);
+            dest.setGenericExcitationSourceID(id, instrumentIndex, lightSource);
+        }
+        catch (NullPointerException e) {
+          continue;
+        }
+
+        try {
+          Map<String, String> map =
+            src.getGenericExcitationSourceMap(instrumentIndex, lightSource);
+          dest.setGenericExcitationSourceMap(map, instrumentIndex, lightSource);
+        }
+        catch (NullPointerException e) { }
+
+        try {
+          String lotNumber = src.getGenericExcitationSourceLotNumber(
+            instrumentIndex, lightSource);
+          dest.setGenericExcitationSourceLotNumber(lotNumber,
+            instrumentIndex, lightSource);
+        }
+        catch (NullPointerException e) { }
+
+        try {
+          String manufacturer = src.getGenericExcitationSourceManufacturer(
+            instrumentIndex, lightSource);
+          dest.setGenericExcitationSourceManufacturer(manufacturer,
+            instrumentIndex, lightSource);
+        }
+        catch (NullPointerException e) { }
+
+        try {
+          String model =
+            src.getGenericExcitationSourceModel(instrumentIndex, lightSource);
+          dest.setGenericExcitationSourceModel(model,
+            instrumentIndex, lightSource);
+        }
+        catch (NullPointerException e) { }
+
+        try {
+          Double power =
+            src.getGenericExcitationSourcePower(instrumentIndex, lightSource);
+          dest.setGenericExcitationSourcePower(power,
+            instrumentIndex, lightSource);
+        }
+        catch (NullPointerException e) { }
+
+        try {
+          String serialNumber = src.getGenericExcitationSourceSerialNumber(
+            instrumentIndex, lightSource);
+          dest.setGenericExcitationSourceSerialNumber(serialNumber,
+            instrumentIndex, lightSource);
         }
         catch (NullPointerException e) { }
       }
@@ -3808,6 +4004,34 @@ public final class MetadataConverter {
         }
         catch (NullPointerException e) { }
       }
+    }
+  }
+
+  private static void convertRootAttributes(MetadataRetrieve src, MetadataStore dest)
+  {
+    String uuid = src.getUUID();
+    if (uuid != null) {
+      dest.setUUID(uuid);
+    }
+
+    String rightsHeld = src.getRightsRightsHeld();
+    if (rightsHeld != null) {
+      dest.setRightsRightsHeld(rightsHeld);
+    }
+
+    String rightsHolder = src.getRightsRightsHolder();
+    if (rightsHolder != null) {
+      dest.setRightsRightsHolder(rightsHolder);
+    }
+
+    String metadataFile = src.getBinaryOnlyMetadataFile();
+    if (metadataFile != null) {
+      dest.setBinaryOnlyMetadataFile(metadataFile);
+    }
+
+    uuid = src.getBinaryOnlyUUID();
+    if (uuid != null) {
+      dest.setBinaryOnlyUUID(uuid);
     }
   }
 


### PR DESCRIPTION
This includes MapAnnotation and GenericExcitationSource, in addition to
a few other things that slipped through the cracks in previous PRs.
