### PR TITLE
Fix MapAnnotation parsing/population during OME-XML conversion

### DIFF
--- a/components/formats-api/src/loci/formats/meta/MetadataConverter.java
+++ b/components/formats-api/src/loci/formats/meta/MetadataConverter.java
@@ -4009,30 +4009,45 @@ public final class MetadataConverter {
 
   private static void convertRootAttributes(MetadataRetrieve src, MetadataStore dest)
   {
-    String uuid = src.getUUID();
-    if (uuid != null) {
-      dest.setUUID(uuid);
+    try {
+      String uuid = src.getUUID();
+      if (uuid != null) {
+        dest.setUUID(uuid);
+      }
     }
+    catch (NullPointerException e) { }
 
-    String rightsHeld = src.getRightsRightsHeld();
-    if (rightsHeld != null) {
-      dest.setRightsRightsHeld(rightsHeld);
+    try {
+      String rightsHeld = src.getRightsRightsHeld();
+      if (rightsHeld != null) {
+        dest.setRightsRightsHeld(rightsHeld);
+      }
     }
+    catch (NullPointerException e) { }
 
-    String rightsHolder = src.getRightsRightsHolder();
-    if (rightsHolder != null) {
-      dest.setRightsRightsHolder(rightsHolder);
+    try {
+      String rightsHolder = src.getRightsRightsHolder();
+      if (rightsHolder != null) {
+        dest.setRightsRightsHolder(rightsHolder);
+      }
     }
+    catch (NullPointerException e) { }
 
-    String metadataFile = src.getBinaryOnlyMetadataFile();
-    if (metadataFile != null) {
-      dest.setBinaryOnlyMetadataFile(metadataFile);
+    try {
+      String metadataFile = src.getBinaryOnlyMetadataFile();
+      if (metadataFile != null) {
+        dest.setBinaryOnlyMetadataFile(metadataFile);
+      }
     }
+    catch (NullPointerException e) { }
 
-    uuid = src.getBinaryOnlyUUID();
-    if (uuid != null) {
-      dest.setBinaryOnlyUUID(uuid);
+    try {
+      String uuid = src.getBinaryOnlyUUID();
+      if (uuid != null) {
+        dest.setBinaryOnlyUUID(uuid);
+      }
     }
+    catch (NullPointerException e) { }
   }
 
 }

--- a/components/formats-bsd/src/loci/formats/in/FakeReader.java
+++ b/components/formats-bsd/src/loci/formats/in/FakeReader.java
@@ -640,7 +640,7 @@ public class FakeReader extends FormatReader {
       }
 
     }
-    
+
     // for indexed color images, create lookup tables
     if (indexed) {
       if (pixelType == FormatTools.UINT8) {

--- a/components/ome-xml/src/ome/xml/model/MapPairs.java
+++ b/components/ome-xml/src/ome/xml/model/MapPairs.java
@@ -151,11 +151,11 @@ public class MapPairs implements OMEModelObject {
     protected Element asXMLElement(Document document, Element pairs)
     {
         if (pairs == null) {
-            if (true/*document.getParentNode().getNodeName().equals("MapAnnotation")*/) {
-                pairs = document.createElementNS(MAPNAMESPACE, "Value");
-            } else {
-                pairs = document.createElementNS(MAPNAMESPACE, "Map");
-            }
+            // a node named "Map" is only desired if we are working with an
+            // instance of Map (a subclass of MapPairs), in which case it
+            // is the subclass' responsibility to ensure that 'pairs' is
+            // a node of the correct name/type
+            pairs = document.createElementNS(MAPNAMESPACE, "Value");
         }
 
         Iterator<Map.Entry<String, String>> entries = map.entrySet().iterator();

--- a/components/xsd-fu/templates-java/OMEXMLModelObject_MapAnnotation_update_Value.template
+++ b/components/xsd-fu/templates-java/OMEXMLModelObject_MapAnnotation_update_Value.template
@@ -10,7 +10,18 @@
 		else if (Value_nodeList.size() != 0)
 		{
 			try {
-				value.update(Value_nodeList.get(0));
+        java.util.Map<String, String> map = new java.util.HashMap<String, String>();
+        NodeList children = Value_nodeList.get(0).getChildNodes();
+
+        for (int i=0; i<children.getLength(); i++) {
+          Node child = children.item(i);
+          if (child.getNodeType() == Node.ELEMENT_NODE) {
+            map.put(
+              ((Element) child).getAttribute("K"), child.getTextContent());
+          }
+        }
+        MapPairs mapPairs = new MapPairs(map);
+        setValue(mapPairs);
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
I'd expect converting an appropriate .fake file to OME-XML/OME-TIFF to work correctly with these commits - conversion should happen without an exception, and `showinf -omexml fake.ome` should show the MapAnnotations in the output (also without an exception).
