### PR TITLE
Fake units

### DIFF
--- a/components/ome-xml/src/ome/units/quantity/Angle.java
+++ b/components/ome-xml/src/ome/units/quantity/Angle.java
@@ -36,7 +36,7 @@ import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
- * A wrapper for the Angle class from the units implimintation.
+ * A wrapper for the Angle class from the units implementation.
  *
  * @author Andrew Patterson &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:ajpatterson@lifesci.dundee.ac.uk">ajpatterson@lifesci.dundee.ac.uk</a>
@@ -142,6 +142,6 @@ public class Angle extends Quantity implements Comparable<Angle>
 
   public Unit<ome.units.quantity.Angle> unit()
   {
-    return UNITS.RADIAN;
+    return unit;
   }
 }

--- a/components/ome-xml/src/ome/units/quantity/ElectricPotential.java
+++ b/components/ome-xml/src/ome/units/quantity/ElectricPotential.java
@@ -36,7 +36,7 @@ import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
- * A wrapper for the ElectricPotential class from the units implimintation.
+ * A wrapper for the ElectricPotential class from the units implementation.
  *
  * @author Andrew Patterson &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:ajpatterson@lifesci.dundee.ac.uk">ajpatterson@lifesci.dundee.ac.uk</a>
@@ -142,6 +142,6 @@ public class ElectricPotential extends Quantity implements Comparable<ElectricPo
 
   public Unit<ome.units.quantity.ElectricPotential> unit()
   {
-    return UNITS.VOLT;
+    return unit;
   }
 }

--- a/components/ome-xml/src/ome/units/quantity/Frequency.java
+++ b/components/ome-xml/src/ome/units/quantity/Frequency.java
@@ -36,7 +36,7 @@ import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
- * A wrapper for the Frequency class from the units implimintation.
+ * A wrapper for the Frequency class from the units implementation.
  *
  * @author Andrew Patterson &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:ajpatterson@lifesci.dundee.ac.uk">ajpatterson@lifesci.dundee.ac.uk</a>
@@ -142,6 +142,6 @@ public class Frequency extends Quantity implements Comparable<Frequency>
 
   public Unit<ome.units.quantity.Frequency> unit()
   {
-    return UNITS.HERTZ;
+    return unit;
   }
 }

--- a/components/ome-xml/src/ome/units/quantity/Length.java
+++ b/components/ome-xml/src/ome/units/quantity/Length.java
@@ -36,7 +36,7 @@ import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
- * A wrapper for the Length class from the units implimintation.
+ * A wrapper for the Length class from the units implementation.
  *
  * @author Andrew Patterson &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:ajpatterson@lifesci.dundee.ac.uk">ajpatterson@lifesci.dundee.ac.uk</a>
@@ -142,6 +142,6 @@ public class Length extends Quantity implements Comparable<Length>
 
   public Unit<ome.units.quantity.Length> unit()
   {
-    return UNITS.METRE;
+    return unit;
   }
 }

--- a/components/ome-xml/src/ome/units/quantity/Power.java
+++ b/components/ome-xml/src/ome/units/quantity/Power.java
@@ -36,7 +36,7 @@ import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
- * A wrapper for the Power class from the units implimintation.
+ * A wrapper for the Power class from the units implementation.
  *
  * @author Andrew Patterson &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:ajpatterson@lifesci.dundee.ac.uk">ajpatterson@lifesci.dundee.ac.uk</a>
@@ -142,6 +142,6 @@ public class Power extends Quantity implements Comparable<Power>
 
   public Unit<ome.units.quantity.Power> unit()
   {
-    return UNITS.WATT;
+    return unit;
   }
 }

--- a/components/ome-xml/src/ome/units/quantity/Pressure.java
+++ b/components/ome-xml/src/ome/units/quantity/Pressure.java
@@ -36,7 +36,7 @@ import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
- * A wrapper for the Pressure class from the units implimintation.
+ * A wrapper for the Pressure class from the units implementation.
  *
  * @author Andrew Patterson &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:ajpatterson@lifesci.dundee.ac.uk">ajpatterson@lifesci.dundee.ac.uk</a>
@@ -142,6 +142,6 @@ public class Pressure extends Quantity implements Comparable<Pressure>
 
   public Unit<ome.units.quantity.Pressure> unit()
   {
-    return UNITS.PASCAL;
+    return unit;
   }
 }

--- a/components/ome-xml/src/ome/units/quantity/Temperature.java
+++ b/components/ome-xml/src/ome/units/quantity/Temperature.java
@@ -36,7 +36,7 @@ import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
- * A wrapper for the Temperature class from the units implimintation.
+ * A wrapper for the Temperature class from the units implementation.
  *
  * @author Andrew Patterson &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:ajpatterson@lifesci.dundee.ac.uk">ajpatterson@lifesci.dundee.ac.uk</a>
@@ -142,6 +142,6 @@ public class Temperature extends Quantity implements Comparable<Temperature>
 
   public Unit<ome.units.quantity.Temperature> unit()
   {
-    return UNITS.KELVIN;
+    return unit;
   }
 }

--- a/components/ome-xml/src/ome/units/quantity/Time.java
+++ b/components/ome-xml/src/ome/units/quantity/Time.java
@@ -36,7 +36,7 @@ import ome.units.unit.Unit;
 import ome.units.UNITS;
 
 /**
- * A wrapper for the Time class from the units implimintation.
+ * A wrapper for the Time class from the units implementation.
  *
  * @author Andrew Patterson &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:ajpatterson@lifesci.dundee.ac.uk">ajpatterson@lifesci.dundee.ac.uk</a>
@@ -142,6 +142,6 @@ public class Time extends Quantity implements Comparable<Time>
 
   public Unit<ome.units.quantity.Time> unit()
   {
-    return UNITS.SECOND;
+    return unit;
   }
 }

--- a/ome.xml
+++ b/ome.xml
@@ -4,7 +4,9 @@
   </description>
 
   <property name="import.dir" value="${basedir}/../antlib/resources"/>
+  <import file="${import.dir}/gitversion.xml" optional="true"/>
   <import file="${import.dir}/global.xml"/>
+  <import file="${import.dir}/version.xml"/>
   <import file="${import.dir}/lifecycle.xml"/>
 
   <target name="dist" depends="generate" description="Hook for OME build to call Bio-Formats">


### PR DESCRIPTION
This introduces `physicalSizeX` etc in the `FakeReader`. String endings can be used to modify what unit is used. e.g.:
- `...&physicalSizeX=1.fake` uses the default
- `...&physicalSizeX=2ft.fake` uses feet, etc.

A couple of other fixes are added here that were necessary to get imports working correctly:
- A build fix which broke with the introduction of version.xml
- The return value of the `unit()` method.
